### PR TITLE
Feature/increase memory size

### DIFF
--- a/build/travis.php.ini
+++ b/build/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 2048M

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -3,6 +3,8 @@ cd ecoci
 git log | head -1
 cd ..
 
+phpenv config-add ./ecoci/build/travis.php.ini
+
 echo "Moving module to subfolder..."
 if [[ *$TRAVIS_EVENT_TYPE* = 'cron' ]]; then git checkout $(git tag | tail -n 1); fi
 mkdir $MODULE_DIR


### PR DESCRIPTION
Due to growth of modules amount, composer requires more memory.
Increase to 2Gbs solved the problem.
Please see build:
https://travis-ci.org/spryker-eco/amazon-pay/builds/386269337?utm_source=github_status&utm_medium=notification