### PR TITLE
feature/eco-2616-add-spryker-products-compatibility

### DIFF
--- a/build/travis.sh
+++ b/build/travis.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "Version of CI scripts:"
 cd ecoci
 git log | head -1
@@ -10,11 +12,14 @@ if [[ *$TRAVIS_EVENT_TYPE* = 'cron' ]]; then git checkout $(git tag | tail -n 1)
 mkdir $MODULE_DIR
 ls -1 | grep -v ^$MODULE_DIR | grep -v ^ecoci | xargs -I{} mv {} $MODULE_DIR
 
-echo "Cloning Shop Suite..."
-git clone https://github.com/spryker-shop/suite.git $SHOP_DIR
+echo "Cloning $PRODUCT_NAME..."
+git clone https://github.com/spryker-shop/$PRODUCT_NAME.git $SHOP_DIR
 cd $SHOP_DIR
+
+composer global require hirak/prestissimo
 composer self-update && composer --version
 composer install --no-interaction
+
 mkdir -p data/DE/logs
 chmod -R 777 data/
 ./config/Shared/ci/travis/install_elasticsearch.sh

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -75,41 +75,42 @@ function checkPHPStan {
     fi
 }
 
-function checkWithLatestShopSuite {
-    echo "Checking module with latest Shop Suite..."
+function checkWithLatestShop {
+    echo "Checking module with latest $PRODUCT_NAME..."
     composer config repositories.ecomodule path "$TRAVIS_BUILD_DIR/$MODULE_DIR"
+    composer update --with-all-dependencies
     composer require "spryker-eco/$MODULE_NAME @dev" --prefer-source
     result=$?
 
     if [ "$result" = 0 ]; then
-        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the modules used in Shop Suite"
+        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the modules used in $PRODUCT_NAME"
         if runTests; then
             buildResult=0
-            checkLatestVersionOfModuleWithShopSuite
+            checkLatestVersionOfModuleWithShop
         fi
     else
-        buildMessage="${buildMessage}\n${RED}$MODULE_NAME is not compatible with the modules used in Shop Suite"
-        checkLatestVersionOfModuleWithShopSuite
+        buildMessage="${buildMessage}\n${RED}$MODULE_NAME is not compatible with the modules used in $PRODUCT_NAME"
+        checkLatestVersionOfModuleWithShop
     fi
 }
 
-function checkLatestVersionOfModuleWithShopSuite {
+function checkLatestVersionOfModuleWithShop {
     echo "Merging composer.json dependencies..."
     updates=`php "$TRAVIS_BUILD_DIR/ecoci/build/merge-composer.php" "$TRAVIS_BUILD_DIR/$MODULE_DIR/composer.json" composer.json "$TRAVIS_BUILD_DIR/$MODULE_DIR/composer.json"`
     if [ "$updates" = "" ]; then
-        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in Shop Suite"
+        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in $PRODUCT_NAME"
         return
     fi
-    buildMessage="${buildMessage}\nUpdated dependencies in module to match Shop Suite\n$updates"
+    buildMessage="${buildMessage}\nUpdated dependencies in module to match $PRODUCT_NAME\n$updates"
     echo "Installing module with updated dependencies..."
     composer require "spryker-eco/$MODULE_NAME @dev" --prefer-source
 
     result=$?
     if [ "$result" = 0 ]; then
-        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in Shop Suite"
+        buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in $PRODUCT_NAME"
         runTests
     else
-        buildMessage="${buildMessage}\n${RED}$MODULE_NAME is not compatible with the latest version of modules used in Shop Suite"
+        buildMessage="${buildMessage}\n${RED}$MODULE_NAME is not compatible with the latest version of modules used in $PRODUCT_NAME"
     fi
 }
 
@@ -120,7 +121,7 @@ if [ $? = 1 ]; then
 fi
 
 cd $SHOP_DIR
-checkWithLatestShopSuite
+checkWithLatestShop
 if [ -d "vendor/spryker-eco/$MODULE_NAME/src" ]; then
     checkArchRules
     checkCodeSniffRules

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -9,6 +9,7 @@ result=0
 function runTests {
     echo "Setup for tests..."
     "$TRAVIS_BUILD_DIR/$SHOP_DIR/vendor/bin/install" -r testing -x frontend
+
     if [ "$?" = 0 ]; then
         buildMessage="${buildMessage}\n${GREEN}Install for testing was successful"
     else
@@ -19,7 +20,7 @@ function runTests {
     echo "Running tests..."
     "$TRAVIS_BUILD_DIR/$SHOP_DIR/vendor/bin/codecept" build -c "vendor/spryker-eco/$MODULE_NAME/"
     "$TRAVIS_BUILD_DIR/$SHOP_DIR/vendor/bin/codecept" run -c "vendor/spryker-eco/$MODULE_NAME/"
-    if [ "$?" = 0 ]; then
+    if [[ "$?" = 0 ]]; then
         buildMessage="${buildMessage}\n${GREEN}Tests are passing"
     else
         buildMessage="${buildMessage}\n${RED}Tests are failing"
@@ -27,6 +28,7 @@ function runTests {
     fi
     cd "$TRAVIS_BUILD_DIR/$SHOP_DIR"
     echo "Tests finished"
+
     return $result
 }
 
@@ -45,7 +47,7 @@ function checkArchRules {
 
 function checkCodeSniffRules {
     licenseFile="$TRAVIS_BUILD_DIR/.license"
-    if [ -f "$licenseFile" ]; then
+    if [[ -f "$licenseFile" ]]; then
         echo "Preparing correct license for code sniffer..."
         cp "$licenseFile" "$TRAVIS_BUILD_DIR/$SHOP_DIR/.license"
     fi
@@ -75,14 +77,28 @@ function checkPHPStan {
     fi
 }
 
+function checkDependencyViolationFinder {
+    echo "Running DependencyViolationFinder"
+    errors=`vendor/bin/console dev:dependency:find "SprykerEco.$MODULE_NAME" -vvv`
+    errorsPresent=$?
+
+    if [[ "$errorsPresent" = "0" ]]; then
+        buildMessage="$buildMessage\n${GREEN}DependencyViolationFinder reports no errors"
+    else
+        echo -e "$errors"
+        buildMessage="$buildMessage\n${RED}DependencyViolationFinder reports some error(s)"
+    fi
+}
+
 function checkWithLatestShop {
     echo "Checking module with latest $PRODUCT_NAME..."
+
     composer config repositories.ecomodule path "$TRAVIS_BUILD_DIR/$MODULE_DIR"
     composer update --with-all-dependencies
     composer require "spryker-eco/$MODULE_NAME @dev" --prefer-source
     result=$?
 
-    if [ "$result" = 0 ]; then
+    if [[ "$result" = 0 ]]; then
         buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the modules used in $PRODUCT_NAME"
         if runTests; then
             buildResult=0
@@ -97,16 +113,17 @@ function checkWithLatestShop {
 function checkLatestVersionOfModuleWithShop {
     echo "Merging composer.json dependencies..."
     updates=`php "$TRAVIS_BUILD_DIR/ecoci/build/merge-composer.php" "$TRAVIS_BUILD_DIR/$MODULE_DIR/composer.json" composer.json "$TRAVIS_BUILD_DIR/$MODULE_DIR/composer.json"`
-    if [ "$updates" = "" ]; then
+    if [[ "$updates" = "" ]]; then
         buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in $PRODUCT_NAME"
         return
     fi
+
     buildMessage="${buildMessage}\nUpdated dependencies in module to match $PRODUCT_NAME\n$updates"
     echo "Installing module with updated dependencies..."
     composer require "spryker-eco/$MODULE_NAME @dev" --prefer-source
 
     result=$?
-    if [ "$result" = 0 ]; then
+    if [[ "$result" = 0 ]]; then
         buildMessage="${buildMessage}\n${GREEN}$MODULE_NAME is compatible with the latest version of modules used in $PRODUCT_NAME"
         runTests
     else
@@ -116,16 +133,20 @@ function checkLatestVersionOfModuleWithShop {
 
 updatedFile="$TRAVIS_BUILD_DIR/$SHOP_DIR/vendor/codeception/codeception/src/Codeception/Application.php"
 grep APPLICATION_ROOT_DIR "$updatedFile"
-if [ $? = 1 ]; then
+if [[ $? = 1 ]]; then
     echo "define('APPLICATION_ROOT_DIR', '$TRAVIS_BUILD_DIR/$SHOP_DIR');" >> "$updatedFile"
 fi
 
 cd $SHOP_DIR
 checkWithLatestShop
-if [ -d "vendor/spryker-eco/$MODULE_NAME/src" ]; then
+
+if [[ -d "vendor/spryker-eco/$MODULE_NAME/src" ]]; then
     checkArchRules
     checkCodeSniffRules
     checkPHPStan
+
+    # will be added:
+    #checkDependencyViolationFinder
 fi
 
 echo -e "$buildMessage"


### PR DESCRIPTION
- Developer(s): @alex-galych

- Ticket: https://spryker.atlassian.net/browse/ECO-2616

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by the legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EcoCi                 | minor (currently 0.x)  |                       |

#### Release Notes

* Added multiple Spryker Products compatibility

-----------------------------------------

#### Module EcoCi

##### Change log

Improvements

* Added `$PRODUCT_NAME` variable to travis.sh and validate.sh
* Added composer parallel install plugin
